### PR TITLE
Disable Timebar if date mismatches

### DIFF
--- a/src/views/Schedule2.vue
+++ b/src/views/Schedule2.vue
@@ -74,7 +74,12 @@ export default Vue.extend({
       const startOfDayAtTodayDate = moment()
         .set('hour', firstTalkStartDateTime.hour())
         .set('minute', firstTalkStartDateTime.minute());
-      const result = moment().diff(startOfDayAtTodayDate, 'minute') * v.ratio + 10;
+
+      var result = moment().diff(startOfDayAtTodayDate, 'minute') * v.ratio + 10;
+      if (firstTalkStartDateTime.dayOfYear() != moment().dayOfYear()) {
+        result = 0;
+      }
+
       if (result < 0) {
         v.nowBarOffset = 10;
       } else if (result > v.containerHeight) {


### PR DESCRIPTION
An hacky way to disable the bar for now. Maybe we should not register update at all to prevent this when on other day.