### PR TITLE
🌐 feat(talk+schedule views and components): translate from FR to EN

### DIFF
--- a/src/components/Error.vue
+++ b/src/components/Error.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="error">Une erreur s'est produite, veuillez essayer à nouveau ou <a
+  <div class="error">An error occurred, please try again or <a
     href="https://github.com/xebia-france/schedule-view-conf-companion/issues"
     target="_blank"
     class="issues"
   >
-    remonter un bug</a>.
+    send a bug report</a>.
   </div>
 </template>
 

--- a/src/components/Header/Header.vue
+++ b/src/components/Header/Header.vue
@@ -15,8 +15,8 @@
     props: ['day'],
     computed: {
       theDay: function () {
-        moment.locale('fr');
-        return moment(this.day).format('D MMMM YYYY')
+        moment.locale('en');
+        return moment(this.day).format('Do MMMM YYYY')
       }
     }
   }

--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="loading">Récupération du planning, veuillez patienter...</div>
+  <div class="loading">Retrieving planning, please wait...</div>
 </template>
 
 <script>

--- a/src/views/TalkInfo.vue
+++ b/src/views/TalkInfo.vue
@@ -16,7 +16,7 @@
     </div>
     <h1>{{ talk.title }}</h1>
     <VueMarkdown class="summary">
-      {{ talk.summary || 'Aucune description.' }}
+      {{ talk.summary || 'No talk summary.' }}
     </VueMarkdown>
     <a
       class="speaker"
@@ -30,9 +30,9 @@
       class="rate"
       target="_blank"
       :href="`https://conf-companion.firebaseapp.com/rate/${talk.conferenceId}#${talk.id}`">
-      Laisser un commentaire
+      Leave a comment
     </a>
-    <router-link class="back" to="/" replace>Retour au planning</router-link>
+    <router-link class="back" to="/" replace>Back to the planning</router-link>
   </section>
 </template>
 


### PR DESCRIPTION
- 🌐 feat(header): use EN locale instead of FR for date
- 🌐 feat(components/Error): translate default error message from FR to EN
- 🌐 feat(component/Loading): translation planning load message from FR to EN
- 🌐 feat(views/TalkInfo): translate strings from FR to EN (empty talk summary, comment button and back to planning button)
